### PR TITLE
Added quake-kube fork with support for Service annotations

### DIFF
--- a/charts/quake-kube/.helmignore
+++ b/charts/quake-kube/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/quake-kube/Chart.yaml
+++ b/charts/quake-kube/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+appVersion: v1.0.7
+description: A Helm chart for criticalstack's quake-kube project
+maintainers:
+- email: chris@chrisfu.co.uk
+  name: chrisfu
+name: quake-kube
+type: application
+version: 0.1.7

--- a/charts/quake-kube/README.md
+++ b/charts/quake-kube/README.md
@@ -1,0 +1,18 @@
+# QuakeKube
+
+A Helm chart for QuakeKube is a Kubernetes-ified version of QuakeJS that runs a dedicated Quake 3 server in a Kubernetes Deployment, and then allow clients to connect via QuakeJS in the browser.
+
+Note: This fork has been slightly modified to support [ExternalDNS](https://github.com/kubernetes-sigs/external-dns) on the NodePort service to easily reach the web service.
+
+Install
+
+```
+# Add the repo
+helm repo add chrisfu https://chrisfu.github.io/chart
+
+# Install
+helm install quake --set quakeServer.eula=true chrisfu/quake-kube
+```
+
+> Sources https://github.com/criticalstack/quake-kube
+> Forked from https://github.com/grahamplata/charts/tree/master/charts/quake-kube

--- a/charts/quake-kube/templates/NOTES.txt
+++ b/charts/quake-kube/templates/NOTES.txt
@@ -1,0 +1,24 @@
+1. Get the application URL by running these commands:
+{{- if contains "NodePort" .Values.service.type }}
+{{- range $key, $val := .Values.service.annotations }}
+  {{- if contains "hostname" $key }}
+  export NODE_PORT=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "quake-kube.fullname" $ }})
+  export NODE_HOST=$(kubectl get --namespace {{ $.Release.Namespace }} -o jsonpath="{.metadata.annotations.external-dns\\.alpha\\.kubernetes\\.io\\/hostname}" services {{ include "quake-kube.fullname" $ }})
+  echo http://$NODE_HOST:$NODE_PORT
+  -or-
+  {{- end }}
+{{- end }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "quake-kube.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "quake-kube.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "quake-kube.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "quake-kube.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/quake-kube/templates/_helpers.tpl
+++ b/charts/quake-kube/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "quake-kube.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "quake-kube.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "quake-kube.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "quake-kube.labels" -}}
+helm.sh/chart: {{ include "quake-kube.chart" . }}
+{{ include "quake-kube.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "quake-kube.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "quake-kube.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "quake-kube.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "quake-kube.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/quake-kube/templates/assets-pvc.yaml
+++ b/charts/quake-kube/templates/assets-pvc.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.persistence.dataDir.enabled (not .Values.persistence.dataDir.existingClaim ) -}}
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: {{ template "quake-kube.fullname" . }}-assets
+  labels:
+{{- include "quake-kube.labels" . | nindent 4 }}
+  annotations:
+  {{- with .Values.persistence.annotations  }}
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
+  {{- if .Values.persistence.storageClass }}
+    volume.beta.kubernetes.io/storage-class: {{ .Values.persistence.storageClass | quote }}
+  {{- else }}
+    volume.alpha.kubernetes.io/storage-class: default
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.persistence.dataDir.Size | quote }}
+{{- if .Values.persistence.storageClass }}
+{{- if (eq "-" .Values.persistence.storageClass) }}
+  storageClassName: ""
+{{- else }}
+  storageClassName: "{{ .Values.persistence.storageClass }}"
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/charts/quake-kube/templates/configmap.yaml
+++ b/charts/quake-kube/templates/configmap.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-configmap
+  labels:
+    {{- include "quake-kube.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    fragLimit: {{ .Values.quakeServer.fragLimit }}
+    timeLimit: {{ .Values.quakeServer.timeLimit }}
+    bot:
+      minPlayers: {{ .Values.quakeServer.bot.minPlayers }}
+    game:
+      motd: {{ .Values.quakeServer.game.motd }}
+      type: {{ .Values.quakeServer.game.type }}
+      forceRespawn: {{ .Values.quakeServer.game.forceRespawn }}
+      inactivity: {{ .Values.quakeServer.game.inactivity }}
+      quadFactor: {{ .Values.quakeServer.game.quadFactor }}
+      weaponRespawn: {{ .Values.quakeServer.game.weaponRespawn }}
+      singlePlayerSkill: {{ .Values.quakeServer.game.singlePlayerSkill }}
+    server:
+      hostname: {{ .Values.quakeServer.server.hostname }}
+      maxClients: {{ .Values.quakeServer.server.maxClients }}
+      password: {{ .Values.quakeServer.server.password }}
+    commands:
+{{- toYaml .Values.quakeServer.commands | nindent 4 }}
+    maps:
+{{- toYaml .Values.quakeServer.maps | nindent 4 }}

--- a/charts/quake-kube/templates/deployment.yaml
+++ b/charts/quake-kube/templates/deployment.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.quakeServer.eula }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "quake-kube.fullname" . }}
+  labels:
+    {{- include "quake-kube.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "quake-kube.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- if or (.Values.podAnnotations) (.Values.prometheus.enabled) }}
+      annotations:
+        {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+        {{- end }}
+      {{- if .Values.prometheus.enabled }}
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '{{ .Values.service.clientPort }}'
+      {{- end }}
+      {{- end }}
+      labels:
+        {{- include "quake-kube.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          command:
+          - q3
+          - server
+          - --config=/config/config.yaml
+          - --content-server=http://localhost:{{ .Values.service.contentPort }}
+          - --agree-eula
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: {{ .Values.service.clientPort }}
+          volumeMounts:
+          - name: {{ .Release.Name }}-configmap
+            mountPath: /config
+          - name: quake3-content
+            mountPath: /assets
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+        - name: content-server
+          command:
+          - q3
+          - content
+          - --seed-content-url=http://content.quakejs.com
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          ports:
+          - containerPort: {{ .Values.service.contentPort }}
+          volumeMounts:
+          - name: quake3-content
+            mountPath: /assets
+          resources:
+{{ toYaml .Values.resources | indent 12 }}
+      volumes:
+        - name: {{ .Release.Name }}-configmap
+          configMap:
+            name: {{ .Release.Name }}-configmap
+        - name: quake3-content
+        {{- if .Values.persistence.dataDir.enabled }}
+          persistentVolumeClaim:
+          {{- if .Values.persistence.dataDir.existingClaim }}
+            claimName: {{ .Values.persistence.dataDir.existingClaim }}
+          {{- else }}
+            claimName: {{ template "quake-kube.fullname" . }}-assets
+          {{- end }}
+        {{- else }}
+          emptyDir: {}
+        {{- end }}
+        {{- range .Values.extraVolumes }}
+        {{- toYaml .volumes | nindent 6 }}
+        {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/quake-kube/templates/service.yaml
+++ b/charts/quake-kube/templates/service.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "quake-kube.fullname" . }}
+  labels:
+    {{- include "quake-kube.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.clientPort }}
+      targetPort: 8080
+      nodePort: 30001
+      name: client
+    - port: {{ .Values.service.serverPort }}
+      targetPort: 27960
+      nodePort: 30003
+      name: server
+    - port: {{ .Values.service.contentPort }}
+      targetPort: 9090
+      nodePort: 30002
+      name: content
+  selector:
+    {{- include "quake-kube.selectorLabels" . | nindent 4 }}

--- a/charts/quake-kube/values.yaml
+++ b/charts/quake-kube/values.yaml
@@ -1,0 +1,124 @@
+# Default values for quake-kube.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# ref: https://docker.io/criticalstack/quake/
+image:
+  repository: criticalstack/quake
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+## Configure resource requests and limits
+## ref: http://kubernetes.io/docs/user-guide/compute-resources/
+##
+resources:
+  requests:
+    memory: 512Mi
+    cpu: 500m
+  limits:
+    memory: 750Mi
+    cpu: 750m
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+# Enables prometheus statistics from server
+prometheus:
+  enabled: false
+
+podAnnotations: {}
+
+quakeServer:
+  # This must be overridden, since we can't accept this for the user.
+  eula: false
+
+  # Server Configuration
+  fragLimit: 25
+  timeLimit: 15m
+
+  bot:
+    minPlayers: 3
+
+  game:
+    motd: "Welcome to Critical Stack"
+    type: FreeForAll
+    forceRespawn: false
+    inactivity: 10m
+    quadFactor: 3
+    weaponRespawn: 3
+    singlePlayerSkill: 2
+
+  server:
+    hostname: "quake-kube"
+    maxClients: 12
+    password: "strongPassword"
+
+  commands:
+    - addbot sarge 2
+  # - seta g_inactivity 600
+  # - seta sv_timeout 120
+
+  maps:
+    - name: q3dm7
+      type: FreeForAll
+      timeLimit: 10m
+    - name: q3wctf1
+      type: CaptureTheFlag
+      captureLimit: 8
+    - name: q3dm17
+      type: FreeForAll
+    - name: q3tourney2
+      type: Tournament
+    - name: q3wctf3
+      type: CaptureTheFlag
+      captureLimit: 8
+    - name: ztn3tourney1
+      type: Tournament
+
+podSecurityContext:
+  # Security context settings
+  runAsUser: 1000
+  fsGroup: 2000
+
+securityContext:
+  {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+persistence:
+  annotations: {}
+  ## If defined, storageClassName: <storageClass>
+  ## If set to "-", storageClassName: "", which disables dynamic provisioning
+  ## If undefined (the default) or set to null, no storageClassName spec is
+  ##   set, choosing the default provisioner.  (gp2 on AWS, standard on
+  ##   GKE, AWS & OpenStack)
+  ##
+  # storageClass: "-"
+  dataDir:
+    # Set this to false if you don't care to persist state between restarts.
+    enabled: false
+    # existingClaim: nil
+    Size: 1Gi
+
+service:
+  type: NodePort
+  clientPort: 8080
+  serverPort: 27960
+  contentPort: 9090
+  # Annotations to add to the service
+  # This is useful in conjunction with external-dns
+  annotations: {}
+    # external-dns.alpha.kubernetes.io/hostname: "quake-kube.example.com"
+    # external-dns.alpha.kubernetes.io/access: "public"
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}


### PR DESCRIPTION
As per summary, I've forked the quake-kube Helm chart from https://github.com/grahamplata/charts with added support for Service annotations so that we can use things like ExternalDNS the NodePort exposed Service.